### PR TITLE
Changed RavenDbEventStore.Find overload type from System.Func<T, bool> to System.Linq.Expressions.Expression<System.Func<T, bool>>

### DIFF
--- a/src/MementoFX.Persistence.RavenDB/RavenDbEventStore.cs
+++ b/src/MementoFX.Persistence.RavenDB/RavenDbEventStore.cs
@@ -1,16 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using MementoFX.Messaging;
+using MementoFX.Persistence.RavenDB.Indexes;
+using MementoFX.Persistence.RavenDB.Listeners;
 using Raven.Abstractions.Data;
 using Raven.Client;
 using Raven.Client.Document;
 using Raven.Client.Indexes;
 using Raven.Json.Linq;
-using MementoFX.Messaging;
-using MementoFX.Persistence.RavenDB.Indexes;
-using MementoFX.Persistence.RavenDB.Listeners;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace MementoFX.Persistence.RavenDB
 {
@@ -68,7 +69,7 @@ namespace MementoFX.Persistence.RavenDB
         /// <typeparam name="T">The type of the event</typeparam>
         /// <param name="filter">The requirement</param>
         /// <returns>The events which satisfy the given requirement</returns>
-        public override IEnumerable<T> Find<T>(Func<T, bool> filter)
+        public override IEnumerable<T> Find<T>(Expression<Func<T, bool>> filter)
         {
             using (var session = DocumentStore.OpenSession())
             {


### PR DESCRIPTION
As described on main project's [issue #6](https://github.com/MementoFX/MementoFX/issues/6) and related [pull request](https://github.com/MementoFX/MementoFX/pull/8), this PR changes the overload types to support `System.Linq.Expressions.Expression<System.Func<T, bool>>` as filter type on RavenDbEventStore implementation.